### PR TITLE
Update react version in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "lodash": "^4.6.1"
   },
   "peerDependencies": {
-    "react": "^0.14.7"
+    "react": "^0.14.0 || ^15.0.0-0"
   }
 }


### PR DESCRIPTION
react-json-schema-proptypes works well with react^15.0.0

the current setting causes peerinvalid error with other dependencies, like react-dom, react-redux, etc.
